### PR TITLE
URL of the Redis server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ var mutex = require('node-mutex')(opts);
 List of available options:
 - `host`: host to connect redis on (`127.0.0.1`)
 - `port`: port to connect redis on (`6379`)
+- `url`:  url to connect redis, this option replace values of host and port. Format: `[redis:]//[[user][:password@]][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]]`
 - `prefix`: port to connect redis on (`mutex:`)
 - `sleepTime`: maximum time in milliseconds to wait before retrying the acquisition of lock (`250`)
 - `expireTime`: time in milliseconds before the `lock` expires (`3000`)

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function( opts ) {
 function Mutex ( opts ) {
   opts = opts || {};
 
+  this.url  = opts.url;
   this.host = opts.host || '127.0.0.1';
   this.port = Number( opts.port || 6379 );
   this.sleepTime = opts.sleepTime || 250;
@@ -35,10 +36,10 @@ function Mutex ( opts ) {
 
   //Init clients if needed
   if ( !this.pub ) {
-    this.pub = redis( this.port, this.host );
+    this.pub = this.url ? redis( this.url ) : redis( this.port, this.host );
   }
   if ( !this.sub ) {
-    this.sub = redis( this.port, this.host );
+    this.sub = this.url ? redis( this.url ) : redis( this.port, this.host );
   }
 
   this.sub.subscribe( this.prefix + 'release' );


### PR DESCRIPTION
I've provided **url** param to initialise redis client using format `[redis:]//[[user][:password@]][host][:port][/db-number][?db=db-number[&password=bar[&option=value]]]`.

Host and port is still working if url is not passed, and example could be:

`
let mutex     = require( 'node-mutex' )({ url: config.redis.url });
`
